### PR TITLE
MLJ docstring polish

### DIFF
--- a/src/commondocs.jl
+++ b/src/commondocs.jl
@@ -1,58 +1,75 @@
+const DOC_MAIN_ARGUMENTS =
+    """
+    # Arguments
 
-const DOC_MAIN_ARGUMENTS = """
-                           # Arguments
+    - `X`: A matrix or table where each row is an observation (vector) of floats
 
-                           - `X`: A matrix or table where each row is an observation (vector) of floats
+    - `y`: An abstract vector of labels that correspond to the observations in X
+    """
+const DOC_RATIOS_ARGUMENT =
+    """
+    - `ratios`: A parameter that controls the amount of oversampling to be done for each
+      class. Can be:
 
-                           - `y`: An abstract vector of labels that correspond to the observations in X
-                           """
-const DOC_RATIOS_ARGUMENT = """
-                            - `ratios`: A parameter that controls the amount of oversampling to be done for each class.
-                                - Can be a dictionary mapping each class to the ratio of the needed number of observations for that 
-                                  class to the initial number of observations of the majority class.
-                                - Can be nothing and in this case each class will be oversampled to the size of the majority class.
-                                - Can be a float and in this case each class will be oversampled to the size of the majority class times the float.
-                            """
-const DOC_RNG_ARGUMENT = """
-                         - `rng::Union{AbstractRNG, Integer}`: Either an `AbstractRNG` object or an `Integer` 
-                             seed to be used with `StableRNG`.\n
-                         """
+      - A dictionary mapping each class to the ratio of the needed number of observations
+        for that class to the initial number of observations of the majority class.
 
-const DOC_RETURNS = """
-# Returns
+      -`nothing`, in which case each class will be oversampled to the size of the majority
+       class.
 
-- `Xover`: A matrix or table like X (if possible, else a columntable) depending on whether X is a matrix or table 
-    respectively that includes original data and the new observations due to oversampling.
+      - A float, in which case each class will be oversampled to the size of the majority
+        class times the float.
+    """
+const DOC_RNG_ARGUMENT =
+    """
+    - `rng::Union{AbstractRNG, Integer}`: Either an `AbstractRNG` object or an `Integer`
+      seed to be used with `StableRNG`.\n
+   """
 
-- `yover`: An abstract vector of labels that includes the original
-    labels and the new instances of them due to oversampling.
-"""
+const DOC_RETURNS =
+    """
+    # Returns
+
+    - `Xover`: A matrix or table like `X` (if possible, else a columntable) depending on
+      whether `X` is a matrix or table respectively that includes original data and the new
+      observations due to oversampling.
+
+    - `yover`: An abstract vector of labels that includes the original labels and the new
+      instances of them due to oversampling.
+    """
 
 
-const DOCS_COMMON_HYPERPARAMETERS = """
-                                    - `ratios=nothing`: A parameter that controls the amount of oversampling to be done for each class.
-                                        - Can be a dictionary mapping each class to the ratio of the needed number of observations
-                                         for that class to the initial number of observations of the majority class.
-                                        - Can be nothing and in this case each class will be oversampled to the size of 
-                                        the majority class.
-                                        - Can be a float and in this case each class will be oversampled 
-                                        to the size of the majority class times the float.
-                                        
-                                    - `rng=Random.default_rng()`: Either an `AbstractRNG` object or an `Integer` 
-                                        seed to be used with `StableRNG`.
-                                    """
+const DOCS_COMMON_HYPERPARAMETERS =
+    """
+    - `ratios=nothing`: A parameter that controls the amount of oversampling to be done
+      for each class. Can be:
 
-const DOCS_COMMON_INPUTS = """
-                           - `X`: A matrix or table where each row is an observation (vector) of floats
+      - A dictionary mapping each class to the ratio of the needed number of observations
+        for that class to the initial number of observations of the majority class.
 
-                           - `y`: An abstract vector of labels that correspond to the observations in `X`
-                           """
+      - `nothing`, in which case each class will be oversampled to the size of the
+        majority class.
 
-const DOCS_COMMON_OUTPUTS = """
-                            - `Xover`: A matrix or table like X (if possible, else a columntable) depending on whether X 
-                                is a matrix or table respectively that includes original data and the new observations 
-                                due to oversampling.
+      - A float, in which case each class will be oversampled to the size of the majority
+        class times the float.
 
-                            - `yover`: An abstract vector of labels that includes the original
-                                labels and the new instances of them due to oversampling.
-                            """
+    - `rng=Random.default_rng()`: Either an `AbstractRNG` object or an `Integer` seed to
+      be used with `StableRNG`.
+    """
+
+const DOCS_COMMON_INPUTS =
+    """
+    - `X`: A matrix or table where each row is an observation (vector) of floats
+
+    - `y`: An abstract vector of labels that correspond to the observations in `X`
+    """
+
+const DOCS_COMMON_OUTPUTS =
+    """
+    - `Xover`: A matrix or table like X (if possible, else a columntable) depending on
+      whether X is a matrix or table respectively that includes original data and the new
+      observations due to oversampling.
+
+    - `yover`: An abstract vector of labels that includes the original labels and the new
+      instances of them due to oversampling.
+    """

--- a/src/smote/interfaces.jl
+++ b/src/smote/interfaces.jl
@@ -24,20 +24,23 @@ Journal of artificial intelligence research, 321-357, 2002.
 # Training data
 
 In MLJ or MLJBase, wrap the model in a machine by
+
     mach = machine(model)
 
-there is no need to provide any data here because the model is a static transformer.
+There is no need to provide any data here because the model is a static transformer.
 
 Likewise, there is no need to `fit!(mach)`.
 
 For default values of the hyper-parameters, model can be constructed by
+
     model = SMOTE()
 
 
 # Hyper-parameters
 
-- `k=5`: Number of nearest neighbors to consider in the SMOTE algorithm.
-    Should be within the range `[1, size(X, 1) - 1]` else set to the nearest of these two values.
+- `k=5`: Number of nearest neighbors to consider in the SMOTE algorithm.  Should be within
+    the range `[1, n - 1]`, where `n` is the number of observations; otherwise set to the
+    nearest of these two values.
 
 $(DOCS_COMMON_HYPERPARAMETERS)
 
@@ -52,43 +55,44 @@ $(DOCS_COMMON_OUTPUTS)
 
 # Operations
 
-- `transform(mach, X, y)`: resample the data `X` and `y` using SMOTE.
-
-
-# Fitted parameters
-
-There are no fitted parameters for this model.
+- `transform(mach, X, y)`: resample the data `X` and `y` using SMOTE, returning both the
+  new and original observations
 
 
 # Example
 
 ```
-using MLJBase
-using Imbalance
+using MLJ
+import Random.seed!
 using MLUtils
-using Random
-using StableRNGs: StableRNG
+import StatsBase.countmap
 
-X, y = MLJBase.@load_iris
-# Take an imbalanced subset of the data
-rand_inds = rand(StableRNG(10), 1:150, 30)
+seed!(12345)
+
+# Generate some imbalanced data:
+X, y = @load_iris # a table and a vector
+rand_inds = rand(1:150, 30)
 X, y = getobs(X, rand_inds), y[rand_inds]
-group_counts(y)
->> Dict{CategoricalArrays.CategoricalValue{String, UInt32}, Int64} with 3 entries:
-  "virginica"  => 5
-  "versicolor" => 15
-  "setosa"     => 10
 
-# Oversample the minority classes to  sizes relative to the majority class
-S = SMOTE(k=10, ratios=Dict("setosa"=>0.9, "versicolor"=> 1.0, "virginica"=>0.7), rng=42)
-mach = machine(S)
+julia> countmap(y)
+Dict{CategoricalArrays.CategoricalValue{String, UInt32}, Int64} with 3 entries:
+  "virginica"  => 12
+  "versicolor" => 5
+  "setosa"     => 13
+
+# load SMOTE model type:
+SMOTE = @load SMOTE pkg=Imbalance
+
+# Oversample the minority classes to  sizes relative to the majority class:
+smote = SMOTE(k=10, ratios=Dict("setosa"=>1.0, "versicolor"=> 0.8, "virginica"=>1.0), rng=42)
+mach = machine(smote)
 Xover, yover = transform(mach, X, y)
-group_counts(yover)
->> Dict{CategoricalArrays.CategoricalValue{String, UInt32}, Int64} with 3 entries:
-  "virginica"  => 10
-  "versicolor" => 15
-  "setosa"     => 14
 
+julia> countmap(yover)
+Dict{CategoricalArrays.CategoricalValue{String, UInt32}, Int64} with 3 entries:
+  "virginica"  => 13
+  "versicolor" => 10
+  "setosa"     => 13
 ```
 
 """


### PR DESCRIPTION
The docstrings look good. The key changes suggested here are around the "Examples" section. Note I have only done SMOTE - you may want to make analogous changes to the other models.

As the doc-strings are targeted at ordinary users, I am suggesting we:

- do `using MLJ` instead of `using MLJBase`
- load the model types using MLJ's `@load` macro to avoid the requirement `using Imbalance`; this won't work until we register your models with the MLJ Model Registry, so for testing the docstring examples you will still to do `using Imbalance`

I've dumped your Imbalance `group_count` method in favour of `StatsBase.countmap`, which is well-known. Generally we try to avoid using any functions from a model packages apart from the the constructors which `@load` essentially exposes.

One **important note** - which you may want to make a separate issue: `StableRNGs` should only be used for dev testing. They are stable over Julia versions, but have poor performance. If your constructor gets an integer `seed`, I suggest you use `rng=Random.Xoshiro(seed)`. 