### PR TITLE
Update codecov config to relax threshold on change

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%


### PR DESCRIPTION
This relaxes the codecov threshold for "fail" (which propagates to the CI badge).

